### PR TITLE
Remove string slicing

### DIFF
--- a/61-searching-strings/lib/searching_strings/boyer_moore.rb
+++ b/61-searching-strings/lib/searching_strings/boyer_moore.rb
@@ -9,7 +9,6 @@ module BoyerMoore
     pattern = pattern.chars
 
     position = 0
-    memo = {}
     matches = []
 
     while position < text.length - pattern.length do
@@ -18,10 +17,7 @@ module BoyerMoore
       char = nil
 
       while j >= 0 do
-        unless memo.key?(i)
-          memo[i] = text.fetch(i)
-        end
-        char = memo[i]
+        char = text.fetch(i)
 
         if char == pattern[j]
           matches.push(i) if j.zero?

--- a/61-searching-strings/lib/searching_strings/boyer_moore.rb
+++ b/61-searching-strings/lib/searching_strings/boyer_moore.rb
@@ -5,6 +5,9 @@ module BoyerMoore
     bad_character_rule = BadCharacterRule.new(pattern)
     good_suffix_rule = GoodSuffixRule.new(pattern)
 
+    text = text.chars if text.respond_to?("chars")
+    pattern = pattern.chars
+
     position = 0
     memo = {}
     matches = []

--- a/61-searching-strings/lib/searching_strings/text.rb
+++ b/61-searching-strings/lib/searching_strings/text.rb
@@ -2,7 +2,7 @@ class Text
   attr_reader :number_of_fetches
 
   def initialize(string)
-    self.string = string
+    self.string = string.chars
     self.number_of_fetches = 0
   end
 

--- a/61-searching-strings/spec/searching_strings/boyer_moore_spec.rb
+++ b/61-searching-strings/spec/searching_strings/boyer_moore_spec.rb
@@ -27,4 +27,19 @@ RSpec.describe BoyerMoore do
     expect(text.number_of_fetches).to be < text.length,
       "The number of comparisons was not sub-linear"
   end
+
+
+  it "finds matches in a regular String" do
+    text = "NEEDELELNNENEEDLEINAHAYNEEEDNEEDLEEHSTACK"
+    matches = described_class.search(text, "NEEDLE")
+
+    expect(matches).to eq([11, 28])
+  end
+
+  it "finds matches in an Array of characters" do
+    text = "NEEDELELNNENEEDLEINAHAYNEEEDNEEDLEEHSTACK".chars
+    matches = described_class.search(text, "NEEDLE")
+
+    expect(matches).to eq([11, 28])
+  end
 end


### PR DESCRIPTION
This brings the runtime from seconds to milliseconds, one could probably search the _complete_ works of Shakespeare now!

It's interesting that this introduces a linear scan to build the character array (and therefore the algorithm itself can't be sublinear!). The core algorithm should probably be made to work on bytes and then we wouldn't have such a problem, although I'm not sure the best way to access the raw bytes of a ruby string without incurring a copy, afaik `str.bytes` is shorthand for `str.each_byte.to_a`.
